### PR TITLE
Only use hardware accelration if its in the .env file.

### DIFF
--- a/src/captions.rs
+++ b/src/captions.rs
@@ -259,7 +259,7 @@ pub fn caption_media(
     }
 
     let output = FfmpegCommand::new()
-        .hwaccel("auto")
+        .hwaccel(std::env::var("HW_ACCEL").unwrap_or("none".to_string()))
         .input(inputs[0])
         .input(inputs[1])
         .args([

--- a/src/media_helpers.rs
+++ b/src/media_helpers.rs
@@ -107,7 +107,7 @@ pub fn resize_media(input: Media, x_size: u16, y_size: u16) -> Result<Media, cra
     // every arg gets a separate line for readability instead of an array.
 
     let output = FfmpegCommand::new()
-        .hwaccel("auto")
+        .hwaccel(std::env::var("HW_ACCEL").unwrap_or("none".to_string()))
         .input(input.file_path.path.as_path().to_str().unwrap()) // input file
         .args([
             // set the dimensions


### PR DESCRIPTION
HW acceleration should not be enabled by default, as it doesn't always automatically detect properly (ie, my machine.)